### PR TITLE
支持海光可信密钥管理(TKM)的密钥隔离功能

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qemu (1:8.2.0+ds-1deepin2) unstable; urgency=medium
+
+  * Support hygon tkm key isolation.
+
+ -- xiongmengbiao <xiongmengbiao@hygon.cn>  Mon Aug 26 14:27:11 2024 +0800
+
 qemu (1:8.2.0+ds-1deepin1) unstable; urgency=medium
 
   * Drop palcode-clipper.

--- a/debian/patches/hw-misc-support-vpsp.patch
+++ b/debian/patches/hw-misc-support-vpsp.patch
@@ -1,0 +1,190 @@
+From b8ef1f6e78d77005756b62e65902d2a9d91275eb Mon Sep 17 00:00:00 2001
+From: xiongmengbiao <xiongmengbiao@hygon.cn>
+Date: Thu, 30 Nov 2023 13:47:21 +0800
+Subject: [PATCH] hw/misc: support vpsp
+
+simulate a psp misc device for support tkm's key isolation
+
+Signed-off-by: xiongmengbiao <xiongmengbiao@hygon.cn>
+---
+ hw/misc/Kconfig     |   4 ++
+ hw/misc/meson.build |   1 +
+ hw/misc/psp.c       | 141 ++++++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 146 insertions(+)
+ create mode 100644 hw/misc/psp.c
+
+diff --git a/hw/misc/Kconfig b/hw/misc/Kconfig
+index cc8a8c14..2ea5c68e 100644
+--- a/hw/misc/Kconfig
++++ b/hw/misc/Kconfig
+@@ -200,4 +200,8 @@ config IOSB
+ config XLNX_VERSAL_TRNG
+     bool
+ 
++config PSP_DEV
++    bool
++    default y
++
+ source macio/Kconfig
+diff --git a/hw/misc/meson.build b/hw/misc/meson.build
+index 36c20d56..28cba0ac 100644
+--- a/hw/misc/meson.build
++++ b/hw/misc/meson.build
+@@ -9,6 +9,7 @@ system_ss.add(when: 'CONFIG_UNIMP', if_true: files('unimp.c'))
+ system_ss.add(when: 'CONFIG_EMPTY_SLOT', if_true: files('empty_slot.c'))
+ system_ss.add(when: 'CONFIG_LED', if_true: files('led.c'))
+ system_ss.add(when: 'CONFIG_PVPANIC_COMMON', if_true: files('pvpanic.c'))
++system_ss.add(when: 'CONFIG_PSP_DEV', if_true: files('psp.c'))
+ 
+ # ARM devices
+ system_ss.add(when: 'CONFIG_PL310', if_true: files('arm_l2x0.c'))
+diff --git a/hw/misc/psp.c b/hw/misc/psp.c
+new file mode 100644
+index 00000000..1cfbab85
+--- /dev/null
++++ b/hw/misc/psp.c
+@@ -0,0 +1,141 @@
++/*
++ * hygon psp device emulation
++ *
++ * Copyright 2024 HYGON Corp.
++ *
++ * This work is licensed under the terms of the GNU GPL, version 2 or (at
++ * your option) any later version. See the COPYING file in the top-level
++ * directory.
++ */
++
++#include "qemu/osdep.h"
++#include "qemu/compiler.h"
++#include "qemu/error-report.h"
++#include "qapi/error.h"
++#include "migration/vmstate.h"
++#include "hw/qdev-properties.h"
++#include "sysemu/runstate.h"
++#include <sys/ioctl.h>
++
++#define TYPE_PSP_DEV "psp"
++OBJECT_DECLARE_SIMPLE_TYPE(PSPDevState, PSP_DEV)
++
++struct PSPDevState {
++    /* Private */
++    DeviceState pdev;
++
++    /* Public */
++    Notifier shutdown_notifier;
++    int dev_fd;
++    uint8_t enabled;
++
++    /**
++     * vid is used to identify a virtual machine in qemu.
++     * When a virtual machine accesses a tkm key,
++     * the TKM module uses different key spaces based on different vids.
++    */
++    uint32_t vid;
++};
++
++#define PSP_DEV_PATH "/dev/hygon_psp_config"
++#define HYGON_PSP_IOC_TYPE      'H'
++#define PSP_IOC_MUTEX_ENABLE    _IOWR(HYGON_PSP_IOC_TYPE, 1, NULL)
++#define PSP_IOC_MUTEX_DISABLE   _IOWR(HYGON_PSP_IOC_TYPE, 2, NULL)
++#define PSP_IOC_VPSP_OPT        _IOWR(HYGON_PSP_IOC_TYPE, 3, NULL)
++
++enum VPSP_DEV_CTRL_OPCODE {
++    VPSP_OP_VID_ADD,
++    VPSP_OP_VID_DEL,
++};
++
++struct psp_dev_ctrl {
++    unsigned char op;
++    union {
++        unsigned int vid;
++        unsigned char reserved[128];
++    } data;
++};
++
++static void psp_dev_destroy(PSPDevState *state)
++{
++    struct psp_dev_ctrl ctrl = { 0 };
++    if (state && state->dev_fd) {
++        if (state->enabled) {
++            ctrl.op = VPSP_OP_VID_DEL;
++            if (ioctl(state->dev_fd, PSP_IOC_VPSP_OPT, &ctrl) < 0) {
++                error_report("VPSP_OP_VID_DEL: %d", -errno);
++            } else {
++                state->enabled = false;
++            }
++        }
++        qemu_close(state->dev_fd);
++        state->dev_fd = 0;
++    }
++}
++
++/**
++ * Guest OS performs shut down operations through 'shutdown' and 'powerdown' event.
++ * The 'powerdown' event will also trigger 'shutdown' in the end,
++ * so only attention to the 'shutdown' event.
++ *
++ * When Guest OS trigger 'reboot' or 'reset' event, to do nothing.
++*/
++static void psp_dev_shutdown_notify(Notifier *notifier, void *data)
++{
++    PSPDevState *state = container_of(notifier, PSPDevState, shutdown_notifier);
++    psp_dev_destroy(state);
++}
++
++static void psp_dev_realize(DeviceState *dev, Error **errp)
++{
++    struct psp_dev_ctrl ctrl = { 0 };
++    PSPDevState *state = PSP_DEV(dev);
++
++    state->dev_fd = qemu_open_old(PSP_DEV_PATH, O_RDWR);
++    if (state->dev_fd < 0) {
++        error_setg(errp, "fail to open %s, errno %d.", PSP_DEV_PATH, errno);
++        goto end;
++    }
++
++    ctrl.op = VPSP_OP_VID_ADD;
++    ctrl.data.vid = state->vid;
++    if (ioctl(state->dev_fd, PSP_IOC_VPSP_OPT, &ctrl) < 0) {
++        error_setg(errp, "psp_dev_realize VPSP_OP_VID_ADD vid %d, return %d", ctrl.data.vid, -errno);
++        goto end;
++    }
++
++    state->enabled = true;
++    state->shutdown_notifier.notify = psp_dev_shutdown_notify;
++    qemu_register_shutdown_notifier(&state->shutdown_notifier);
++end:
++    return;
++}
++
++static struct Property psp_dev_properties[] = {
++    DEFINE_PROP_UINT32("vid", PSPDevState, vid, 0),
++    DEFINE_PROP_END_OF_LIST(),
++};
++
++static void psp_dev_class_init(ObjectClass *klass, void *data)
++{
++    DeviceClass *dc = DEVICE_CLASS(klass);
++
++    dc->desc = "PSP Device";
++    dc->realize = psp_dev_realize;
++    set_bit(DEVICE_CATEGORY_MISC, dc->categories);
++    device_class_set_props(dc, psp_dev_properties);
++}
++
++static const TypeInfo psp_dev_info = {
++    .name = TYPE_PSP_DEV,
++    .parent = TYPE_DEVICE,
++    .instance_size = sizeof(PSPDevState),
++    .class_init = psp_dev_class_init,
++};
++
++static void psp_dev_register_types(void)
++{
++    type_register_static(&psp_dev_info);
++}
++
++type_init(psp_dev_register_types)
+-- 
+2.41.0
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -13,3 +13,4 @@ slof-remove-user-and-host-from-release-version.patch
 slof-ensure-ld-is-called-with-C-locale.patch
 openbios-spelling-endianess.patch
 disable-xen-on-x32.patch
+hw-misc-support-vpsp.patch


### PR DESCRIPTION
Guest使用VID来识别特定的TKM（可信密钥管理）密钥空间。执行 qemu-system-x86_64时，可以使用 -device psp,vid=<NUM> 参数指定 Guest 虚拟机的密钥空间。

验证过程：
![20240826115714](https://github.com/user-attachments/assets/4de47c3c-018c-488d-bbd4-5f71841d39fd)

关联的kernel PR：[[6.6] Support Hygon TKM (Trusted Key Management) virtualization](https://github.com/deepin-community/kernel/pull/386)