### PR TITLE
fix: disable powerpc64 system data

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,16 @@
+qemu (1:8.2.0+ds-1deepin4) unstable; urgency=medium
+
+  * Drop powerpc64 system data (Skiboot, VoF, SLOF) as we don't provide
+    cross toolchains for big-endian PowerPC targets.
+  * Disable librbd (Ceph) support for riscv64 as it currently does not build.
+
+ -- Mingcong Bai <baimingcong@uniontech.com>  Wed, 09 Oct 2024 15:16:20 +0800
+
 qemu (1:8.2.0+ds-1deepin3) unstable; urgency=medium
 
   * Support live migration of Hygon CSV/CSV2 VM, support reboot CSV/CSV2 VM
 
- -- hanliyang <hanliyang@hygon.cn> Tue, 3 Sep 2024 11:27:30 2024 +0800
+ -- hanliyang <hanliyang@hygon.cn>  Tue, 3 Sep 2024 11:27:30 2024 +0800
 
 qemu (1:8.2.0+ds-1deepin2) unstable; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -73,8 +73,8 @@ Build-Depends-Arch:
  libcacard-dev,
 # --enable-pixman
  libpixman-1-dev,
-# --enable-rbd		amd64 arm64 mips64el ppc64el ppc64 riscv64 s390x sparc64
- librbd-dev            [amd64 arm64 mips64el ppc64el ppc64 riscv64 s390x sparc64],
+# --enable-rbd		amd64 arm64 mips64el ppc64el ppc64 s390x sparc64
+ librbd-dev            [amd64 arm64 mips64el ppc64el ppc64 s390x sparc64],
 # gluster is 64bit-only: #1039604
 # --enable-glusterfs	 amd64 arm64 ppc64el ppc64 riscv64 mips64el s390x ia64 sparc64
  libglusterfs-dev	[amd64 arm64 ppc64el ppc64 riscv64 mips64el s390x ia64 sparc64],
@@ -137,10 +137,6 @@ Build-Depends-Indep:
 # gcc-alpha-linux-gnu,
 # u-boot code
  gcc-powerpc-linux-gnu [amd64], bc,
-# skiboot firmware, openbios
- gcc-powerpc64-linux-gnu [amd64],
-# skiboot includes <openssl/something.h>
- libssl-dev,
 # openbios
  gcc-sparc64-linux-gnu [amd64], fcode-utils, xsltproc,
 # hppa-firmware
@@ -200,11 +196,11 @@ Description: extra block backend modules for qemu-system and qemu-utils
 Package: qemu-system-data
 Architecture: all
 Multi-Arch: foreign
-Conflicts: sgabios, qemu-skiboot, openbios-sparc, openbios-ppc, qemu-slof,
-Replaces:  sgabios, openbios-sparc, openbios-ppc, qemu-slof,
+Conflicts: sgabios, openbios-sparc, openbios-ppc
+Replaces:  sgabios, openbios-sparc, openbios-ppc,
  qemu-system-ppc (<< 1:6.1-4~),
 Breaks: qemu-system-ppc (<< 1:6.1-4~),
-Provides: qemu-keymaps, sgabios, qemu-skiboot, openbios-sparc, openbios-ppc, qemu-slof,
+Provides: qemu-keymaps, sgabios, openbios-sparc, openbios-ppc
 Depends: ${misc:Depends}
 Description: QEMU full system emulation (data files)
  This package provides architecture-neutral data files

--- a/debian/control-in
+++ b/debian/control-in
@@ -74,8 +74,8 @@ Build-Depends-Arch:
  libcacard-dev,
 # --enable-pixman
  libpixman-1-dev,
-# --enable-rbd		amd64 arm64 mips64el ppc64el ppc64 riscv64 s390x sparc64
- librbd-dev            [amd64 arm64 mips64el ppc64el ppc64 riscv64 s390x sparc64],
+# --enable-rbd		amd64 arm64 mips64el ppc64el ppc64 s390x sparc64
+ librbd-dev            [amd64 arm64 mips64el ppc64el ppc64 s390x sparc64],
 # gluster is 64bit-only: #1039604
 # --enable-glusterfs	 amd64 arm64 ppc64el ppc64 riscv64 mips64el s390x ia64 sparc64
  libglusterfs-dev	[amd64 arm64 ppc64el ppc64 riscv64 mips64el s390x ia64 sparc64],
@@ -138,10 +138,6 @@ Build-Depends-Indep:
 # gcc-alpha-linux-gnu,
 # u-boot code
  gcc-powerpc-linux-gnu [amd64], bc,
-# skiboot firmware, openbios
- gcc-powerpc64-linux-gnu [amd64],
-# skiboot includes <openssl/something.h>
- libssl-dev,
 # openbios
  gcc-sparc64-linux-gnu [amd64], fcode-utils, xsltproc,
 # hppa-firmware
@@ -206,11 +202,11 @@ Description: extra block backend modules for qemu-system and qemu-utils
 Package: qemu-system-data
 Architecture: all
 Multi-Arch: foreign
-Conflicts: sgabios, qemu-skiboot, openbios-sparc, openbios-ppc, qemu-slof,
-Replaces:  sgabios, openbios-sparc, openbios-ppc, qemu-slof,
+Conflicts: sgabios, openbios-sparc, openbios-ppc
+Replaces:  sgabios, openbios-sparc, openbios-ppc,
  qemu-system-ppc (<< 1:6.1-4~),
 Breaks: qemu-system-ppc (<< 1:6.1-4~),
-Provides: qemu-keymaps, sgabios, qemu-skiboot, openbios-sparc, openbios-ppc, qemu-slof,
+Provides: qemu-keymaps, sgabios, openbios-sparc, openbios-ppc
 Depends: ${misc:Depends}
 Description: QEMU full system emulation (data files)
  This package provides architecture-neutral data files

--- a/debian/rules
+++ b/debian/rules
@@ -545,31 +545,6 @@ install-openbios: build-openbios
 		b/openbios/obj-sparc64/QEMU,VGA.bin
 sysdata-components += openbios
 
-### powernv firmware in roms/skiboot
-build-skiboot: b/skiboot/skiboot.lid
-b/skiboot/skiboot.lid: | roms/skiboot/.version
-	mkdir -p b/skiboot
-# skiboot makefiles makes it difficult to *add* an option to CFLAGS.
-# Abuse OPTS= for this, with the default being -Os.
-	grep -q '^OPTS=-Os$$' roms/skiboot/Makefile.main || \
-	  { echo "review OPTS= in skiboot/Makefile.main"; false; }
-	${MAKE} -C b/skiboot -f ${CURDIR}/roms/skiboot/Makefile \
-	  SRC=${CURDIR}/roms/skiboot \
-	  OPTS='-Os -ffile-prefix-map="${CURDIR}/roms/skiboot/"=' \
-	  CROSS_COMPILE=${PPC64_CROSSPFX} V=${V}
-install-skiboot: b/skiboot/skiboot.lid
-	install -m 0644 -t ${sysdataidir} $<
-sysdata-components += skiboot
-
-build-vof: b/vof/vof.bin
-b/vof/vof.bin: | b
-	mkdir -p b/vof
-	printf 'CC=$${CROSS}gcc\nLD=$${CROSS}ld\nOBJCOPY=$${CROSS}objcopy\nEXTRA_CFLAGS=-m32 -mbig-endian' > b/vof/config.mak
-	${MAKE} -C b/vof CROSS=${PPC64_CROSSPFX} SRC_DIR=../../pc-bios/vof -f../../pc-bios/vof/Makefile
-install-vof: b/vof/vof.bin
-	install -m 0644 -t ${sysdataidir} $<
-sysdata-components += vof
-
 ### u-boot-e500 (u-boot.e500)
 build-u-boot-e500: b/u-boot/build-e500/u-boot
 b/u-boot/build-e500/u-boot: | b
@@ -624,15 +599,6 @@ b/qemu-palcode/palcode-clipper: | b
 install-palcode-clipper: b/qemu-palcode/palcode-clipper
 	install -m 0644 $< ${sysdataidir}/palcode-clipper
 # sysdata-components += palcode-clipper
-
-### SLOF
-build-slof: b/SLOF/boot_rom.bin
-b/SLOF/boot_rom.bin: | b
-	cp -al roms/SLOF b/
-	env -u LDFLAGS -u CFLAGS $(MAKE) -C b/SLOF qemu CROSS=${PPC64_CROSSPFX} V=${V}
-install-slof: b/SLOF/boot_rom.bin
-	install -m 0644 $< ${sysdataidir}/slof.bin
-sysdata-components += slof
 
 ### s390x firmware in pc-bios/s390-ccw
 build-s390x-fw: b/s390fw/built


### PR DESCRIPTION
Drop powerpc64 system data (Skiboot, VoF, SLOF) as we don't provide cross toolchains for big-endian PowerPC targets.