### PR TITLE
fix qemu fmt issue

### DIFF
--- a/debian/binfmt-install
+++ b/debian/binfmt-install
@@ -8,7 +8,7 @@ case "$#$PACKAGE" in
   *) echo "usage: $0 <qemu-user-binfmt|qemu-user-static>"; exit 1 ;;
 esac
 
-fmts="aarch64 alpha arm armeb cris hexagon hppa i386 m68k microblaze mips mipsel mipsn32 mipsn32el mips64 mips64el ppc ppc64 ppc64le riscv32 riscv64 s390x sh4 sh4eb sparc sparc32plus sparc64 x86_64 xtensa xtensaeb"
+fmts="aarch64 alpha arm armeb cris hexagon hppa i386 loongarch64 m68k microblaze mips mipsel mipsn32 mipsn32el mips64 mips64el ppc ppc64 ppc64le riscv32 riscv64 s390x sh4 sh4eb sparc sparc32plus sparc64 x86_64 xtensa xtensaeb"
 removed_fmts="ppc64abi32"
 
 # linux ELF_OSABI(byte7) can be 0 (traditional,SYSV) or 3 (GNU/LINUX extensions)
@@ -86,6 +86,7 @@ sparc32plus_magic='\x7f\x45\x4c\x46\x01\x02\x01\x00\x00\x00\x00\x00\x00\x00\x00\
 case "$DEB_HOST_ARCH" in
   amd64 | i386 | x32) omit="i386|x86_64|x32" ;;
   arm | armel | armhf | arm64) omit="arm|aarch64" ;;
+  loong64) omit="loongarch64" ;;
   ppc64 | powerpc) omit="ppc|ppc64|ppc64abi32" ;;
   ppc64el) omit="ppc64le" ;;
   riscv64) omit="riscv32|riscv64" ;;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qemu (1:8.2.0+ds-1deepin13) unstable; urgency=medium
+
+  * fix qemu fmt issue.
+
+ -- Xianglai Li <lixianglai@loongson.cn>  Fri, 28 Mar 2025 17:39:03 +0800
+
 qemu (1:8.2.0+ds-1deepin12) unstable; urgency=medium
 
   * Add recommends for qemu-efi-loongarch64.


### PR DESCRIPTION
binfmt does not filter out loongarch correctly,
and only omit is needed to filter out calls to
loongarch instead of deleting them directly.

This change fixes a bug in packaging
the loongarch root file system on x86.