### PR TITLE
hw/loongarch/boot: Adjust the loading position of the initrd

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qemu (1:8.2.0+ds-1deepin16) UNRELEASED; urgency=medium
+
+  * Adjust the loading position of the initrd on loongarch
+
+ -- Xianglai Li <lixianglai@loongson.cn>  Sat, 26 Jul 2025 12:04:08 +0800
+
 qemu (1:8.2.0+ds-1deepin15) unstable; urgency=medium
 
   * sync kvm head file from upstream.

--- a/debian/patches/hw-loongarch-boot-Adjust-the-loading-position-of-the.patch
+++ b/debian/patches/hw-loongarch-boot-Adjust-the-loading-position-of-the.patch
@@ -1,0 +1,96 @@
+From c604fd180009d293308ab881e0babc217aab239f Mon Sep 17 00:00:00 2001
+From: Xianglai Li <lixianglai@loongson.cn>
+Date: Wed, 26 Mar 2025 17:02:37 +0800
+Subject: [PATCH 1/2] hw/loongarch/boot: Adjust the loading position of the
+ initrd
+
+When only the -kernel parameter is used to load the elf kernel,
+the initrd is loaded in the ram. If the initrd size is too large,
+the loading fails, resulting in a VM startup failure.
+This patch first loads initrd near the kernel.
+When the nearby memory space of the kernel is insufficient,
+it tries to load it to the starting position of high memory.
+If there is still not enough, qemu will report an error
+and ask the user to increase the memory space for the
+virtual machine to boot.
+
+Signed-off-by: Xianglai Li <lixianglai@loongson.cn>
+---
+ hw/loongarch/boot.c | 53 +++++++++++++++++++++++++++++++++++++--------
+ 1 file changed, 44 insertions(+), 9 deletions(-)
+
+diff --git a/hw/loongarch/boot.c b/hw/loongarch/boot.c
+index 53dcefbb..13f0c376 100644
+--- a/hw/loongarch/boot.c
++++ b/hw/loongarch/boot.c
+@@ -171,6 +171,48 @@ static uint64_t cpu_loongarch_virt_to_phys(void *opaque, uint64_t addr)
+     return addr & MAKE_64BIT_MASK(0, TARGET_PHYS_ADDR_SPACE_BITS);
+ }
+ 
++static void find_initrd_loadoffset(struct loongarch_boot_info *info,
++                uint64_t kernel_high, ssize_t kernel_size)
++{
++    hwaddr base, size, gap, low_end;
++    ram_addr_t initrd_end, initrd_start;
++
++    base = VIRT_LOWMEM_BASE;
++    gap = VIRT_LOWMEM_SIZE;
++    initrd_start = ROUND_UP(kernel_high + 4 * kernel_size, 64 * KiB);
++    initrd_end = initrd_start + initrd_size;
++
++    size = info->ram_size;
++    low_end = base + MIN(size, gap);
++    if (initrd_end <= low_end) {
++        initrd_offset = initrd_start;
++        return ;
++    }
++
++    if (size <= gap) {
++        error_report("The low memory too small for initial ram disk '%s',"
++             "You need to expand the memory space",
++             info->initrd_filename);
++        exit(1);
++    }
++
++    /*
++     * Try to load initrd in the high memory
++     */
++    size -= gap;
++    base = VIRT_HIGHMEM_BASE;
++    initrd_start = ROUND_UP(base, 64 * KiB);
++    if (initrd_size <= size) {
++        initrd_offset = initrd_start;
++        return ;
++    }
++
++    error_report("The high memory too small for initial ram disk '%s',"
++         "You need to expand the memory space",
++         info->initrd_filename);
++    exit(1);
++}
++
+ static int64_t load_kernel_info(struct loongarch_boot_info *info)
+ {
+     uint64_t kernel_entry, kernel_low, kernel_high;
+@@ -192,16 +234,9 @@ static int64_t load_kernel_info(struct loongarch_boot_info *info)
+     if (info->initrd_filename) {
+         initrd_size = get_image_size(info->initrd_filename);
+         if (initrd_size > 0) {
+-            initrd_offset = ROUND_UP(kernel_high + 4 * kernel_size, 64 * KiB);
+-
+-            if (initrd_offset + initrd_size > info->ram_size) {
+-                error_report("memory too small for initial ram disk '%s'",
+-                             info->initrd_filename);
+-                exit(1);
+-            }
+-
++            find_initrd_loadoffset(info, kernel_high, kernel_size);
+             initrd_size = load_image_targphys(info->initrd_filename, initrd_offset,
+-                                              info->ram_size - initrd_offset);
++                                              initrd_size);
+         }
+ 
+         if (initrd_size == (target_ulong)-1) {
+-- 
+2.41.0
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -149,3 +149,4 @@ hw-misc-psp-pin-the-hugepage-memory-specified-by-mem2.patch
 0076-target-loongarch-fix-vcpu-reset-command-word-issue.patch
 0077-target-i386-csv-Release-CSV3-shared-pages-after-unma.patch
 sync-header-file-from-upstream.patch 
+hw-loongarch-boot-Adjust-the-loading-position-of-the.patch 


### PR DESCRIPTION
When only the -kernel parameter is used to load the elf kernel, the initrd is loaded in the ram. If the initrd size is too large, the loading fails, resulting in a VM startup failure. This patch first loads initrd near the kernel.
When the nearby memory space of the kernel is insufficient, it tries to load it to the starting position of high memory. If there is still not enough, qemu will report an error and ask the user to increase the memory space for the virtual machine to boot.