### PR TITLE
Add support for Hygon Dharma and Chengdu CPU models

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qemu (1:8.2.0+ds-1deepin17) unstable; urgency=medium
+
+  * Add support for Hygon Dharma and Chengdu CPU models.
+
+ -- dongshengyuan <dongshengyuan@uniontech.com>  Tue, 03 Mar 2026 19:08:11 +0800
+
 qemu (1:8.2.0+ds-1deepin16) unstable; urgency=medium
 
   * feat: Add support for ARM-CCA confidential computing features

--- a/debian/patches/001-target-i386-Add-Hygon-Dhyana-v3-CPU-model.patch
+++ b/debian/patches/001-target-i386-Add-Hygon-Dhyana-v3-CPU-model.patch
@@ -1,0 +1,43 @@
+From 234631d8572a225d06258786db531f99974557af Mon Sep 17 00:00:00 2001
+From: Yongchen Lou <louyongchen@hygon.cn>
+Date: Fri, 10 Oct 2025 09:30:12 +0000
+Subject: [PATCH] target/i386: Add Hygon Dhyana-v3 CPU model
+
+Add the following feature bits for Dhyana CPU model:
+perfctr-core, clzero, xsaveerptr, aes, pclmulqdq, sha-ni
+
+Disable xsaves feature bit for Erratum 1386
+
+Signed-off-by: Yongchen Lou <louyongchen@hygon.cn>
+---
+ target/i386/cpu.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/target/i386/cpu.c b/target/i386/cpu.c
+index cd16cb893..6a1d44156 100644
+--- a/target/i386/cpu.c
++++ b/target/i386/cpu.c
+@@ -4657,6 +4657,20 @@ static const X86CPUDefinition builtin_x86_defs[] = {
+                   { /* end of list */ }
+               },
+             },
++            { .version = 3,
++              .props = (PropValue[]) {
++                  { "xsaves", "off" },
++                  { "perfctr-core", "on" },
++                  { "clzero", "on" },
++                  { "xsaveerptr", "on" },
++                  { "aes", "on" },
++                  { "pclmulqdq", "on" },
++                  { "sha-ni", "on" },
++                  { "model-id",
++                      "Hygon Dhyana-v3 processor" },
++                  { /* end of list */ }
++              },
++            },
+             { /* end of list */ }
+         }
+     },
+-- 
+2.43.0
+

--- a/debian/patches/002-target-i386-Add-new-Hygon-Dharma-CPU-model.patch
+++ b/debian/patches/002-target-i386-Add-new-Hygon-Dharma-CPU-model.patch
@@ -1,0 +1,133 @@
+From 70ecda1fb8466091860aa2f793cfc64add76e1dc Mon Sep 17 00:00:00 2001
+From: Yongchen Lou <louyongchen@hygon.cn>
+Date: Fri, 10 Oct 2025 11:33:24 +0000
+Subject: [PATCH] target/i386: Add new Hygon 'Dharma' CPU model
+
+Add the following feature bits compare to Dhyana CPU model:
+stibp, ibrs, umip, ssbd
+
+Signed-off-by: Yongchen Lou <louyongchen@hygon.cn>
+---
+ target/i386/cpu.c | 99 +++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 99 insertions(+)
+
+diff --git a/target/i386/cpu.c b/target/i386/cpu.c
+index 6a1d44156..eff5418a0 100644
+--- a/target/i386/cpu.c
++++ b/target/i386/cpu.c
+@@ -2162,6 +2162,56 @@ static const CPUCaches epyc_genoa_cache_info = {
+     },
+ };
+ 
++static CPUCaches dharma_cache_info = {
++    .l1d_cache = &(CPUCacheInfo) {
++        .type = DATA_CACHE,
++        .level = 1,
++        .size = 32 * KiB,
++        .line_size = 64,
++        .associativity = 8,
++        .partitions = 1,
++        .sets = 64,
++        .lines_per_tag = 1,
++        .self_init = 1,
++        .no_invd_sharing = true,
++    },
++    .l1i_cache = &(CPUCacheInfo) {
++        .type = INSTRUCTION_CACHE,
++        .level = 1,
++        .size = 32 * KiB,
++        .line_size = 64,
++        .associativity = 8,
++        .partitions = 1,
++        .sets = 64,
++        .lines_per_tag = 1,
++        .self_init = 1,
++        .no_invd_sharing = true,
++    },
++    .l2_cache = &(CPUCacheInfo) {
++        .type = UNIFIED_CACHE,
++        .level = 2,
++        .size = 512 * KiB,
++        .line_size = 64,
++        .associativity = 8,
++        .partitions = 1,
++        .sets = 1024,
++        .lines_per_tag = 1,
++    },
++    .l3_cache = &(CPUCacheInfo) {
++        .type = UNIFIED_CACHE,
++        .level = 3,
++        .size = 16 * MiB,
++        .line_size = 64,
++        .associativity = 16,
++        .partitions = 1,
++        .sets = 16384,
++        .lines_per_tag = 1,
++        .self_init = true,
++        .inclusive = true,
++        .complex_indexing = true,
++    },
++};
++
+ /* The following VMX features are not supported by KVM and are left out in the
+  * CPU definitions:
+  *
+@@ -4902,6 +4952,55 @@ static const X86CPUDefinition builtin_x86_defs[] = {
+         .model_id = "AMD EPYC-Genoa Processor",
+         .cache_info = &epyc_genoa_cache_info,
+     },
++    {
++        .name = "Dharma",
++        .level = 0xd,
++        .vendor = CPUID_VENDOR_HYGON,
++        .family = 24,
++        .model = 4,
++        .stepping = 0,
++        .features[FEAT_1_EDX] =
++            CPUID_SSE2 | CPUID_SSE | CPUID_FXSR | CPUID_MMX | CPUID_CLFLUSH |
++            CPUID_PSE36 | CPUID_PAT | CPUID_CMOV | CPUID_MCA | CPUID_PGE |
++            CPUID_MTRR | CPUID_SEP | CPUID_APIC | CPUID_CX8 | CPUID_MCE |
++            CPUID_PAE | CPUID_MSR | CPUID_TSC | CPUID_PSE | CPUID_DE |
++            CPUID_VME | CPUID_FP87,
++        .features[FEAT_1_ECX] =
++            CPUID_EXT_RDRAND | CPUID_EXT_F16C | CPUID_EXT_AVX |
++            CPUID_EXT_XSAVE | CPUID_EXT_AES | CPUID_EXT_POPCNT |
++            CPUID_EXT_MOVBE | CPUID_EXT_SSE42 | CPUID_EXT_SSE41 |
++            CPUID_EXT_CX16 | CPUID_EXT_FMA | CPUID_EXT_SSSE3 |
++            CPUID_EXT_MONITOR | CPUID_EXT_PCLMULQDQ | CPUID_EXT_SSE3,
++        .features[FEAT_8000_0001_EDX] =
++            CPUID_EXT2_LM | CPUID_EXT2_RDTSCP | CPUID_EXT2_PDPE1GB |
++            CPUID_EXT2_FFXSR | CPUID_EXT2_MMXEXT | CPUID_EXT2_NX |
++            CPUID_EXT2_SYSCALL,
++        .features[FEAT_8000_0001_ECX] =
++            CPUID_EXT3_OSVW | CPUID_EXT3_3DNOWPREFETCH |
++            CPUID_EXT3_MISALIGNSSE | CPUID_EXT3_SSE4A | CPUID_EXT3_ABM |
++            CPUID_EXT3_CR8LEG | CPUID_EXT3_SVM | CPUID_EXT3_LAHF_LM |
++            CPUID_EXT3_TOPOEXT | CPUID_EXT3_PERFCORE,
++        .features[FEAT_8000_0008_EBX] =
++            CPUID_8000_0008_EBX_CLZERO | CPUID_8000_0008_EBX_XSAVEERPTR |
++            CPUID_8000_0008_EBX_IBPB | CPUID_8000_0008_EBX_IBRS |
++            CPUID_8000_0008_EBX_STIBP | CPUID_8000_0008_EBX_AMD_SSBD,
++        .features[FEAT_7_0_EBX] =
++            CPUID_7_0_EBX_FSGSBASE | CPUID_7_0_EBX_BMI1 | CPUID_7_0_EBX_AVX2 |
++            CPUID_7_0_EBX_SMEP | CPUID_7_0_EBX_BMI2 | CPUID_7_0_EBX_RDSEED |
++            CPUID_7_0_EBX_ADX | CPUID_7_0_EBX_SMAP | CPUID_7_0_EBX_CLFLUSHOPT |
++            CPUID_7_0_EBX_SHA_NI,
++        .features[FEAT_7_0_ECX] = CPUID_7_0_ECX_UMIP,
++        .features[FEAT_XSAVE] =
++            CPUID_XSAVE_XSAVEOPT | CPUID_XSAVE_XSAVEC |
++            CPUID_XSAVE_XGETBV1,
++        .features[FEAT_6_EAX] =
++            CPUID_6_EAX_ARAT,
++        .features[FEAT_SVM] =
++            CPUID_SVM_NPT | CPUID_SVM_NRIPSAVE,
++        .xlevel = 0x8000001E,
++        .model_id = "Hygon Dharma Processor",
++        .cache_info = &dharma_cache_info,
++    },
+ };
+ 
+ /*
+-- 
+2.43.0
+

--- a/debian/patches/003-target-i386-Add-new-Hygon-Chengdu-CPU-model.patch
+++ b/debian/patches/003-target-i386-Add-new-Hygon-Chengdu-CPU-model.patch
@@ -1,0 +1,90 @@
+From 69e3871dc5375a9c4813e54843cafe17f91a3598 Mon Sep 17 00:00:00 2001
+From: Yongchen Lou <louyongchen@hygon.cn>
+Date: Fri, 10 Oct 2025 11:35:26 +0000
+Subject: [PATCH] target/i386: Add new Hygon 'Chengdu' CPU model
+
+Add the following feature bits compare to Dharma CPU model:
+avx512f avx512dq avx512ifma clwb avx512cd avx512bw
+avx512vl avx512_bf16 wbnoinvd avx512vbmi avx512_vbmi2
+gfni vaes vpclmulqdq avx512_vnni avx512_bitalg
+avx512_vpopcntdq
+
+Signed-off-by: Yongchen Lou <louyongchen@hygon.cn>
+---
+ target/i386/cpu.c | 60 +++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 60 insertions(+)
+
+diff --git a/target/i386/cpu.c b/target/i386/cpu.c
+index eff5418a0..1378ff2e0 100644
+--- a/target/i386/cpu.c
++++ b/target/i386/cpu.c
+@@ -5001,6 +5001,66 @@ static const X86CPUDefinition builtin_x86_defs[] = {
+         .model_id = "Hygon Dharma Processor",
+         .cache_info = &dharma_cache_info,
+     },
++    {
++        .name = "Chengdu",
++        .level = 0xd,
++        .vendor = CPUID_VENDOR_HYGON,
++        .family = 24,
++        .model = 7,
++        .stepping = 0,
++        .features[FEAT_1_EDX] =
++            CPUID_SSE2 | CPUID_SSE | CPUID_FXSR | CPUID_MMX | CPUID_CLFLUSH |
++            CPUID_PSE36 | CPUID_PAT | CPUID_CMOV | CPUID_MCA | CPUID_PGE |
++            CPUID_MTRR | CPUID_SEP | CPUID_APIC | CPUID_CX8 | CPUID_MCE |
++            CPUID_PAE | CPUID_MSR | CPUID_TSC | CPUID_PSE | CPUID_DE |
++            CPUID_VME | CPUID_FP87,
++        .features[FEAT_1_ECX] =
++            CPUID_EXT_RDRAND | CPUID_EXT_F16C | CPUID_EXT_AVX |
++            CPUID_EXT_XSAVE | CPUID_EXT_AES | CPUID_EXT_POPCNT |
++            CPUID_EXT_MOVBE | CPUID_EXT_SSE42 | CPUID_EXT_SSE41 |
++            CPUID_EXT_CX16 | CPUID_EXT_FMA | CPUID_EXT_SSSE3 |
++            CPUID_EXT_MONITOR | CPUID_EXT_PCLMULQDQ | CPUID_EXT_SSE3,
++        .features[FEAT_8000_0001_EDX] =
++            CPUID_EXT2_LM | CPUID_EXT2_RDTSCP | CPUID_EXT2_PDPE1GB |
++            CPUID_EXT2_FFXSR | CPUID_EXT2_MMXEXT | CPUID_EXT2_NX |
++            CPUID_EXT2_SYSCALL,
++        .features[FEAT_8000_0001_ECX] =
++            CPUID_EXT3_OSVW | CPUID_EXT3_3DNOWPREFETCH |
++            CPUID_EXT3_MISALIGNSSE | CPUID_EXT3_SSE4A | CPUID_EXT3_ABM |
++            CPUID_EXT3_CR8LEG | CPUID_EXT3_SVM | CPUID_EXT3_LAHF_LM |
++            CPUID_EXT3_TOPOEXT | CPUID_EXT3_PERFCORE,
++        .features[FEAT_8000_0008_EBX] =
++            CPUID_8000_0008_EBX_CLZERO | CPUID_8000_0008_EBX_XSAVEERPTR |
++            CPUID_8000_0008_EBX_WBNOINVD | CPUID_8000_0008_EBX_IBPB |
++            CPUID_8000_0008_EBX_IBRS | CPUID_8000_0008_EBX_STIBP |
++            CPUID_8000_0008_EBX_AMD_SSBD,
++        .features[FEAT_7_0_EBX] =
++            CPUID_7_0_EBX_FSGSBASE | CPUID_7_0_EBX_BMI1 | CPUID_7_0_EBX_AVX2 |
++            CPUID_7_0_EBX_SMEP | CPUID_7_0_EBX_BMI2 | CPUID_7_0_EBX_AVX512F |
++            CPUID_7_0_EBX_AVX512DQ | CPUID_7_0_EBX_RDSEED |
++            CPUID_7_0_EBX_ADX | CPUID_7_0_EBX_SMAP | CPUID_7_0_EBX_AVX512IFMA |
++            CPUID_7_0_EBX_CLFLUSHOPT | CPUID_7_0_EBX_CLWB |
++            CPUID_7_0_EBX_AVX512CD | CPUID_7_0_EBX_SHA_NI |
++            CPUID_7_0_EBX_AVX512BW | CPUID_7_0_EBX_AVX512VL,
++        .features[FEAT_7_0_ECX] =
++            CPUID_7_0_ECX_AVX512_VBMI | CPUID_7_0_ECX_UMIP |
++            CPUID_7_0_ECX_AVX512_VBMI2 | CPUID_7_0_ECX_GFNI |
++            CPUID_7_0_ECX_VAES | CPUID_7_0_ECX_VPCLMULQDQ |
++            CPUID_7_0_ECX_AVX512VNNI | CPUID_7_0_ECX_AVX512BITALG |
++            CPUID_7_0_ECX_AVX512_VPOPCNTDQ,
++        .features[FEAT_7_1_EAX] =
++            CPUID_7_1_EAX_AVX512_BF16,
++        .features[FEAT_XSAVE] =
++            CPUID_XSAVE_XSAVEOPT | CPUID_XSAVE_XSAVEC |
++            CPUID_XSAVE_XGETBV1,
++        .features[FEAT_6_EAX] =
++            CPUID_6_EAX_ARAT,
++        .features[FEAT_SVM] =
++            CPUID_SVM_NPT | CPUID_SVM_NRIPSAVE,
++        .xlevel = 0x80000020,
++        .model_id = "Hygon Chengdu Processor",
++        .cache_info = &dharma_cache_info,
++    },
+ };
+ 
+ /*
+-- 
+2.43.0
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -180,3 +180,6 @@ ARM-CCA/0026-hw-tpm-Add-TPM-event-log.patch
 ARM-CCA/0027-hw-core-loader-Add-fields-to-RomLoaderNotify.patch
 ARM-CCA/0028-target-arm-kvm-rme-Add-measurement-log.patch
 ARM-CCA/0029-hw-arm-virt-Add-measurement-log-for-confidential-boo.patch
+001-target-i386-Add-Hygon-Dhyana-v3-CPU-model.patch
+002-target-i386-Add-new-Hygon-Dharma-CPU-model.patch
+003-target-i386-Add-new-Hygon-Chengdu-CPU-model.patch


### PR DESCRIPTION
#########################################################################
#
#       Hygon Qemu Patch for Version 8.2.0 Release Notes
#
# Copyright 2016-2025 by SW Group, Chengdu Haiguang IC Design Co., Ltd.
#
#########################################################################

2025-10-15:
1. Release files:
    001-target-i386-Add-Hygon-Dhyana-v3-CPU-model.patch
    002-target-i386-Add-new-Hygon-Dharma-CPU-model.patch
    003-target-i386-Add-new-Hygon-Chengdu-CPU-model.patch
2. Add Hygon Dhyana-v3 CPU model, add following features:
    perfctr-core, clzero, xsaveerptr, aes, pclmulqdq, sha-ni
3. Add new Hygon 'Dharma' CPU model, add following features based on Dhyana-v3:
    stibp, ibrs, umip, ssbd  
4. Add Hygon Chengdu CPU model, add following features:
    avx512f avx512dq avx512ifma clwb avx512cd avx512bw avx512vl 
    avx512_bf16 wbnoinvd avx512vbmi avx512_vbmi2 gfni vaes 
    vpclmulqdq avx512_vnni avx512_bitalgavx512_vpopcntdq
5. Based on source code from qemu-8.2.0
